### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/trunk/OS X/PanDOI.wdgt/pandoi.js
+++ b/trunk/OS X/PanDOI.wdgt/pandoi.js
@@ -34,7 +34,7 @@ function srch(s)
       if ( value.substr( 0, 20 ) == "doi:10.1594/pangaea." )
         url = "http://doi.pangaea.de/" + value.substr( 4 );
       else
-        url = "http://dx.doi.org/" + value.substr( 4 );
+        url = "https://doi.org/" + value.substr( 4 );
   }
   
   if ( value.substr( 0, 4 ) == "hdl:" )

--- a/trunk/OS X/Source/pandoi.js
+++ b/trunk/OS X/Source/pandoi.js
@@ -34,7 +34,7 @@ function srch(s)
       if ( value.substr( 0, 20 ) == "doi:10.1594/pangaea." )
         url = "http://doi.pangaea.de/" + value.substr( 4 );
       else
-        url = "http://dx.doi.org/" + value.substr( 4 );
+        url = "https://doi.org/" + value.substr( 4 );
   }
   
   if ( value.substr( 0, 4 ) == "hdl:" )

--- a/trunk/Windows/Source/pandoi.html
+++ b/trunk/Windows/Source/pandoi.html
@@ -73,7 +73,7 @@ function openWindow()
       if ( value.substr( 0, 20 ) == "doi:10.1594/pangaea." )
         url = "http://doi.pangaea.de/" + value.substr( 4 );
       else
-        url = "http://dx.doi.org/" + value.substr( 4 );
+        url = "https://doi.org/" + value.substr( 4 );
   }
   
   if ( value.substr( 0, 4 ) == "hdl:" )


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update any code that generates new DOI links, just as PANGAEA's website does already.

Cheers!